### PR TITLE
Generate dataset

### DIFF
--- a/feded/datasets/larc.py
+++ b/feded/datasets/larc.py
@@ -10,7 +10,7 @@ from feded.datasets import TabularDataset
 from feded.preprocessing import read_csv, filter_df_by_values, \
     make_binary_indicator_column, generate_categorical_feature_dict, \
     minmax_scale_numeric_columns, generate_missing_value_indicator
-
+from feded.preprocessing.larc import make_prev_term_gpa_column
 # the prediction target
 
 DEFAULT_LARC_TARGET_COLNAME = "CRSE_GRD_OFFCL_CD"
@@ -70,8 +70,9 @@ DEFAULT_LARC_NUMERIC_FEATURES = [  # numeric and binary features
     "CMBN_CLASS_ENRL_TOTAL_NBR",  # Combined Class Enrollment Total Number
     # "EXCL_CLASS_CUM_GPA",
     "HS_GPA",  # High School Grade Point Average
+    # TODO(jpgard): PREV_TERM_CUM_GPA should be included as a feature!
     # "PREV_TERM_CUM_GPA",  # Previous Term Cumulative Grade Point Average
-    "STDNT_BIRTH_YR",  # Student Birth Year TODO(jpgard): take (birth year - term year)
+    # "STDNT_BIRTH_YR",  # Student Birth Year TODO(jpgard): take (birth year - term year)
     # to obtain an additional feature for approximate age
     "TERM_CD",  # Term Code
 ]
@@ -148,6 +149,7 @@ class LarcDataset(TabularDataset):
         df.dropna(inplace=True)
         print("[INFO] dataset rows after dropping NAs: {}".format(df.shape[0]))
         df = minmax_scale_numeric_columns(df, self.numeric_columns)
+        df = make_prev_term_gpa_column(df)
         # shuffle the data
         df = shuffle(df)
         print("final preprocessed dataset description:")

--- a/feded/datasets/larc.py
+++ b/feded/datasets/larc.py
@@ -10,9 +10,8 @@ from feded.datasets import TabularDataset
 from feded.preprocessing import read_csv, filter_df_by_values, \
     make_binary_indicator_column, generate_categorical_feature_dict, \
     minmax_scale_numeric_columns, generate_missing_value_indicator
-from feded.preprocessing.larc import make_prev_term_gpa_column
-# the prediction target
 
+# the prediction target
 DEFAULT_LARC_TARGET_COLNAME = "CRSE_GRD_OFFCL_CD"
 
 # the column to use for generating clients; this should be a column which universities
@@ -149,7 +148,6 @@ class LarcDataset(TabularDataset):
         df.dropna(inplace=True)
         print("[INFO] dataset rows after dropping NAs: {}".format(df.shape[0]))
         df = minmax_scale_numeric_columns(df, self.numeric_columns)
-        df = make_prev_term_gpa_column(df)
         # shuffle the data
         df = shuffle(df)
         print("final preprocessed dataset description:")

--- a/feded/preprocessing/larc.py
+++ b/feded/preprocessing/larc.py
@@ -1,0 +1,8 @@
+import pandas as pd
+
+SID_COLNAME = "STDNT_ID"
+TERM_COLNAME = "TERM_CD"
+SNAPSHT_COLNAME = "SNPSHT_RPT_DT"
+
+def make_prev_term_gpa_column(df):
+    return df

--- a/scripts/generate_combined_larc_dataset.py
+++ b/scripts/generate_combined_larc_dataset.py
@@ -39,7 +39,8 @@ TEST_VAL_TERM_CDS = {
 def read_csv_from_bz2(fp, index_cols, **read_csv_args):
     print("[INFO] reading {}".format(fp))
     with bz2.open(fp) as file:
-        df = pd.read_csv(file, index_col=index_cols, **read_csv_args)
+        df = pd.read_csv(file, index_col=index_cols, **read_csv_args).rename(
+            columns={"#SNPSHT_RPT_DT": "SNPSHT_RPT_DT"})
     return df
 
 
@@ -84,15 +85,15 @@ def main(stdnt_info_fp,
     }
 
     stdnt_info = read_csv_from_bz2(
-        stdnt_info_fp, index_cols=("STDNT_ID",), **read_csv_args)
+        stdnt_info_fp, index_cols=("#SNPSHT_RPT_DT", "STDNT_ID",), **read_csv_args)
     stdnt_term_class_info = read_csv_from_bz2(
         stdnt_term_class_info_fp,
-        index_cols=("TERM_CD", "STDNT_ID", "CLASS_NBR"),
+        index_cols=("#SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID", "CLASS_NBR"),
         **read_csv_args)
     # drop the duplicated and redundant column when reading stdnt_term_info
     stdnt_term_info = read_csv_from_bz2(
         stdnt_term_info_fp,
-        index_cols=("TERM_CD", "STDNT_ID"),
+        index_cols=("#SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID"),
         **read_csv_args).drop(columns="TERM_SHORT_DES")
 
     for df in (stdnt_info, stdnt_term_class_info, stdnt_term_info):

--- a/scripts/generate_combined_larc_dataset.py
+++ b/scripts/generate_combined_larc_dataset.py
@@ -138,7 +138,8 @@ def main(stdnt_info_fp,
                 # Filter the data using cutoff_term_cd
                 train_df = larc[larc["TERM_CD"].astype(int) < cutoff_term_cd]
                 # Shuffle the training data in place and reset the index
-                train_df = train_df.sample(frac=1).reset_index(drop=True)
+                train_df = train_df.sample(frac=1, random_state=47895).reset_index(
+                    drop=True)
                 # Write the results to separate training files
                 for i in range(n_train):
                     mode_out_fp = osp.join(mode_out_dir, "train_{}.csv".format(i))

--- a/scripts/generate_combined_larc_dataset.py
+++ b/scripts/generate_combined_larc_dataset.py
@@ -3,29 +3,21 @@ Read the individual LARC tables and join them into a single student-term-course 
 
 Example usage:
 
-# mock LARC dataset
-python scripts/generate_combined_larc_dataset.py \
-    --prsn_identifying_info_fp data/larc-mock/PRSN_IDNTFYNG_INFO.csv \
-    --stdnt_info_fp data/larc-mock/STDNT_INFO.csv \
-    --stdnt_term_class_info_fp data/larc-mock/STDNT_TERM_CLASS_INFO.csv \
-    --stdnt_term_info_fp data/larc-mock/STDNT_TERM_INFO.csv \
-    --stdnt_term_trnsfr_info_fp data/larc-mock/STDNT_TERM_TRNSFR_INFO.csv \
-    --outdir data/larc-mock/
-
 # full LARC dataset (excluding transfer table)
 python scripts/generate_combined_larc_dataset.py \
-    --stdnt_info_fp data/LARC/LARC_20190924_STDNT_INFO.csv \
-    --stdnt_term_class_info_fp data/LARC/LARC_20190924_STDNT_TERM_CLASS_INFO.csv \
-    --stdnt_term_info_fp data/LARC/LARC_20190924_STDNT_TERM_INFO.csv \
+    --stdnt_info_fp data/LARC/LARC_20190924_STDNT_INFO.csv.bz2 \
+    --stdnt_term_class_info_fp data/LARC/LARC_20190924_STDNT_TERM_CLASS_INFO.csv.bz2 \
+    --stdnt_term_info_fp data/LARC/LARC_20190924_STDNT_TERM_INFO.csv.bz2 \
     --outdir data/larc-split/ \
     --generate_ttv
 """
 
-import pandas as pd
 import argparse
 import os
 import os.path as osp
+import bz2
 
+import pandas as pd
 
 TERM_CDS = {
     # the term codes to use for the validation dataset; should be the second-to-last full
@@ -41,6 +33,13 @@ TERM_CDS = {
         "2220"  # WN 2019
     ]
 }
+
+
+def read_csv_from_bz2(fp, index_cols, **read_csv_args):
+    print("[INFO] reading {}".format(fp))
+    with bz2.open(fp) as file:
+        df = pd.read_csv(file, index_col=index_cols, **read_csv_args)
+    return df
 
 
 def main(stdnt_info_fp,
@@ -59,7 +58,7 @@ def main(stdnt_info_fp,
     :param outdir:
     :param prsn_identifying_info_fp:
     :param stdnt_term_trnsfr_info_fp:
-    :param generate_ttv: boolean indicator for whether to generate train-test split.
+    :param generate_ttv: boolean indicator for whether to generate train-test-val split.
     :return:
     """
 
@@ -70,20 +69,17 @@ def main(stdnt_info_fp,
         "dtype": "object",
     }
 
-    print("[INFO] reading {}".format(stdnt_info_fp))
-    stdnt_info = pd.read_csv(stdnt_info_fp,
-                             index_col=("SNPSHT_RPT_DT", "STDNT_ID"),
-                             **read_csv_args)
-    print("[INFO] reading {}".format(stdnt_term_class_info_fp))
-    stdnt_term_class_info = pd.read_csv(stdnt_term_class_info_fp,
-                                        index_col=("SNPSHT_RPT_DT", "TERM_CD",
-                                                   "STDNT_ID", "CLASS_NBR"),
-                                        **read_csv_args)
-    # drop the duplicated column
-    print("[INFO] reading {}".format(stdnt_term_info_fp))
-    stdnt_term_info = pd.read_csv(stdnt_term_info_fp,
-                                  index_col=("SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID"),
-                                  **read_csv_args).drop(columns="TERM_SHORT_DES")
+    stdnt_info = read_csv_from_bz2(
+        stdnt_info_fp, index_cols=("SNPSHT_RPT_DT", "STDNT_ID"), **read_csv_args)
+    stdnt_term_class_info = read_csv_from_bz2(
+        stdnt_term_class_info_fp,
+        index_cols=("SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID", "CLASS_NBR"),
+        **read_csv_args)
+    # drop the duplicated and redundant column when reading stdnt_term_info
+    stdnt_term_info = read_csv_from_bz2(
+        stdnt_term_info_fp,
+        index_cols=("SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID"),
+        **read_csv_args).drop(columns="TERM_SHORT_DES")
 
     # we want a student-term-class level dataset; join the other data onto this df
     larc = stdnt_term_class_info \
@@ -104,6 +100,7 @@ def main(stdnt_info_fp,
         print("[ERROR] transfer data join not implemented")
         raise NotImplementedError
     larc.reset_index(inplace=True)
+    import ipdbl;ipdb.set_trace()
     # ensure no data is lost or duplicated in joins
     assert len(larc) == len(stdnt_term_class_info)
     if not generate_ttv:  # write the entire dataset
@@ -123,10 +120,10 @@ def main(stdnt_info_fp,
                 os.mkdir(mode_out_dir)
             if mode == "train":
                 # filter the data using cutoff_term_cd
-                larc[larc["TERM_CD"].astype(int) < cutoff_term_cd]\
+                larc[larc["TERM_CD"].astype(int) < cutoff_term_cd] \
                     .to_csv(mode_out_fp, index=False)
             else:  # mode is val or test; write that data
-                larc[larc["TERM_CD"].isin(TERM_CDS[mode])]\
+                larc[larc["TERM_CD"].isin(TERM_CDS[mode])] \
                     .to_csv(mode_out_fp, index=False)
 
 

--- a/scripts/generate_combined_larc_dataset.py
+++ b/scripts/generate_combined_larc_dataset.py
@@ -10,6 +10,7 @@ python scripts/generate_combined_larc_dataset.py \
     --stdnt_term_info_fp data/LARC/LARC_20190924_STDNT_TERM_INFO.csv.bz2 \
     --outdir data/larc-split/ \
     --generate_ttv
+
 """
 
 import argparse
@@ -36,7 +37,7 @@ TEST_VAL_TERM_CDS = {
 }
 
 
-def read_csv_from_bz2(fp, index_cols, **read_csv_args):
+def read_csv_from_bz2(fp, index_cols: list, **read_csv_args):
     print("[INFO] reading {}".format(fp))
     with bz2.open(fp) as file:
         df = pd.read_csv(file, **read_csv_args).rename(
@@ -87,15 +88,15 @@ def main(stdnt_info_fp,
     }
 
     stdnt_info = read_csv_from_bz2(
-        stdnt_info_fp, index_cols=("SNPSHT_RPT_DT", "STDNT_ID",), **read_csv_args)
+        stdnt_info_fp, index_cols=["SNPSHT_RPT_DT", "STDNT_ID",], **read_csv_args)
     stdnt_term_class_info = read_csv_from_bz2(
         stdnt_term_class_info_fp,
-        index_cols=("SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID", "CLASS_NBR"),
+        index_cols=["SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID", "CLASS_NBR"],
         **read_csv_args)
     # drop the duplicated and redundant column when reading stdnt_term_info
     stdnt_term_info = read_csv_from_bz2(
         stdnt_term_info_fp,
-        index_cols=("SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID"),
+        index_cols=["SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID"],
         **read_csv_args).drop(columns="TERM_SHORT_DES")
 
     # for df in (stdnt_info, stdnt_term_class_info, stdnt_term_info):
@@ -109,8 +110,8 @@ def main(stdnt_info_fp,
     if prsn_identifying_info_fp:
         print("[INFO] reading {}".format(prsn_identifying_info_fp))
         # for this table, we rename column PRSN_ID before setting the index
-        prsn_identifying_info = pd.read_csv(
-            prsn_identifying_info_fp, index_col=["SNPSHT_RPT_DT", "STDNT_ID"],
+        prsn_identifying_info = read_csv_from_bz2(
+            prsn_identifying_info_fp, index_cols=["SNPSHT_RPT_DT", "STDNT_ID"],
             **read_csv_args).rename(
             columns={"PRSN_ID": "STDNT_ID"}) \
             .astype({"STDNT_ID": "int64"})

--- a/scripts/generate_combined_larc_dataset.py
+++ b/scripts/generate_combined_larc_dataset.py
@@ -89,15 +89,15 @@ def main(stdnt_info_fp,
     }
 
     stdnt_info = read_csv_from_bz2(
-        stdnt_info_fp, index_cols=["SNPSHT_RPT_DT", "STDNT_ID", ], **read_csv_args)
+        stdnt_info_fp, index_cols=["SNPSHT_RPT_DT", "STDNT_ID"], **read_csv_args)
     stdnt_term_class_info = read_csv_from_bz2(
         stdnt_term_class_info_fp,
-        index_cols=["SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID", "CLASS_NBR"],
+        index_cols=["SNPSHT_RPT_DT", "STDNT_ID", "TERM_CD", "CLASS_NBR"],
         **read_csv_args)
     # drop the duplicated and redundant column when reading stdnt_term_info
     stdnt_term_info = read_csv_from_bz2(
         stdnt_term_info_fp,
-        index_cols=["SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID"],
+        index_cols=["SNPSHT_RPT_DT", "STDNT_ID", "TERM_CD"],
         **read_csv_args).drop(columns="TERM_SHORT_DES")
 
     # for df in (stdnt_info, stdnt_term_class_info, stdnt_term_info):
@@ -107,8 +107,7 @@ def main(stdnt_info_fp,
     print("[INFO] joining datasets")
     larc = stdnt_term_class_info \
         .join(stdnt_term_info, how="inner", on=("SNPSHT_RPT_DT", "STDNT_ID", "TERM_CD")) \
-        .join(stdnt_info, how="inner", on=("SNPSHT_RPT_DT", "STDNT_ID",))
-    import ipdb;ipdb.set_trace()
+        .join(stdnt_info, how="inner", on=("SNPSHT_RPT_DT", "STDNT_ID"))
     if prsn_identifying_info_fp:
         print("[INFO] reading {}".format(prsn_identifying_info_fp))
         # for this table, we rename column PRSN_ID before setting the index

--- a/scripts/generate_combined_larc_dataset.py
+++ b/scripts/generate_combined_larc_dataset.py
@@ -85,7 +85,7 @@ def main(stdnt_info_fp,
         "na_values": ('', ' '),
         "keep_default_na": True,
         "dtype": "object",
-        "nrows": 100000,  # TODO(jpgard): remove this after debugging
+        # "nrows": 10**,  # TODO(jpgard): remove this after debugging
     }
 
     stdnt_info = read_csv_from_bz2(
@@ -106,8 +106,9 @@ def main(stdnt_info_fp,
     # we want a student-term-class level dataset; join the other data onto this df
     print("[INFO] joining datasets")
     larc = stdnt_term_class_info \
-        .join(stdnt_term_info, how="left", on=("SNPSHT_RPT_DT", "STDNT_ID", "TERM_CD")) \
-        .join(stdnt_info, how="left", on=("SNPSHT_RPT_DT", "STDNT_ID",))
+        .join(stdnt_term_info, how="inner", on=("SNPSHT_RPT_DT", "STDNT_ID", "TERM_CD")) \
+        .join(stdnt_info, how="inner", on=("SNPSHT_RPT_DT", "STDNT_ID",))
+    import ipdb;ipdb.set_trace()
     if prsn_identifying_info_fp:
         print("[INFO] reading {}".format(prsn_identifying_info_fp))
         # for this table, we rename column PRSN_ID before setting the index

--- a/scripts/generate_combined_larc_dataset.py
+++ b/scripts/generate_combined_larc_dataset.py
@@ -100,7 +100,7 @@ def main(stdnt_info_fp,
         print("[ERROR] transfer data join not implemented")
         raise NotImplementedError
     larc.reset_index(inplace=True)
-    import ipdbl;ipdb.set_trace()
+    import ipdb;ipdb.set_trace()
     # ensure no data is lost or duplicated in joins
     assert len(larc) == len(stdnt_term_class_info)
     if not generate_ttv:  # write the entire dataset

--- a/scripts/generate_combined_larc_dataset.py
+++ b/scripts/generate_combined_larc_dataset.py
@@ -85,7 +85,6 @@ def main(stdnt_info_fp,
         "na_values": ('', ' '),
         "keep_default_na": True,
         "dtype": "object",
-        # "nrows": 10**,  # TODO(jpgard): remove this after debugging
     }
 
     stdnt_info = read_csv_from_bz2(

--- a/scripts/generate_combined_larc_dataset.py
+++ b/scripts/generate_combined_larc_dataset.py
@@ -18,6 +18,7 @@ import bz2
 import numpy as np
 import os
 import os.path as osp
+from typing import Optional
 
 import pandas as pd
 
@@ -41,7 +42,7 @@ def read_csv_from_bz2(fp, index_cols: list, **read_csv_args):
     print("[INFO] reading {}".format(fp))
     with bz2.open(fp) as file:
         df = pd.read_csv(file, **read_csv_args).rename(
-            columns={"#SNPSHT_RPT_DT": "SNPSHT_RPT_DT"})\
+            columns={"#SNPSHT_RPT_DT": "SNPSHT_RPT_DT"}) \
             .set_index(index_cols)
     return df
 
@@ -64,7 +65,7 @@ def main(stdnt_info_fp,
          prsn_identifying_info_fp=None,
          stdnt_term_trnsfr_info_fp=None,
          generate_ttv=False,
-         n_train=100
+         n_train: Optional[int] = None
          ):
     """
     Generate a combined dataset by merging the CSV files along the correct indices.
@@ -88,7 +89,7 @@ def main(stdnt_info_fp,
     }
 
     stdnt_info = read_csv_from_bz2(
-        stdnt_info_fp, index_cols=["SNPSHT_RPT_DT", "STDNT_ID",], **read_csv_args)
+        stdnt_info_fp, index_cols=["SNPSHT_RPT_DT", "STDNT_ID", ], **read_csv_args)
     stdnt_term_class_info = read_csv_from_bz2(
         stdnt_term_class_info_fp,
         index_cols=["SNPSHT_RPT_DT", "TERM_CD", "STDNT_ID", "CLASS_NBR"],
@@ -149,8 +150,8 @@ def main(stdnt_info_fp,
                 for i in range(n_train):
                     mode_out_fp = osp.join(mode_out_dir, "train_{}.csv".format(i))
                     print("[INFO] writing to {}".format(mode_out_fp))
-                    train_df[np.arange(len(train_df)) % n_train == 0].to_csv(mode_out_fp,
-                                                                             index=False)
+                    train_df[np.arange(len(train_df)) % n_train == 0]\
+                        .to_csv(mode_out_fp, index=False)
             else:  # mode is val or test; write that data
                 mode_out_fp = osp.join(mode_out_dir, mode + ".csv")
                 print("[INFO] writing to {}".format(mode_out_fp))
@@ -170,6 +171,6 @@ if __name__ == "__main__":
     parser.add_argument("--outdir", help="directory to write dataset to")
     parser.add_argument("--generate_ttv", action="store_true", default=False)
     parser.add_argument("--n_train", help="number of training csvs to generate",
-                        type=int)
+                        type=int, default=100)
     args = parser.parse_args()
     main(**vars(args))

--- a/scripts/generate_combined_larc_dataset.py
+++ b/scripts/generate_combined_larc_dataset.py
@@ -42,7 +42,7 @@ def read_csv_from_bz2(fp, index_cols: list, **read_csv_args):
     with bz2.open(fp) as file:
         df = pd.read_csv(file, **read_csv_args).rename(
             columns={"#SNPSHT_RPT_DT": "SNPSHT_RPT_DT"})\
-            .set_index(index_cols, inplace=True)
+            .set_index(index_cols)
     return df
 
 

--- a/train.py
+++ b/train.py
@@ -157,7 +157,8 @@ def main(data_fp: str, logdir: str, training_config: TrainingConfig,
     dataset.read_data(data_fp)
     if train_federated:
         federated_logdir = os.path.join(logdir, "federated")
-        execute_federated_training(dataset, logdir, training_config, model_config)
+        execute_federated_training(dataset, federated_logdir, training_config,
+                                   model_config)
     if train_centralized:
         centralized_logdir = os.path.join(logdir, "centralized")
         execute_centralized_training(dataset, centralized_logdir, training_config,

--- a/train.py
+++ b/train.py
@@ -4,8 +4,8 @@ Train a FedEd model.
 Usage (note the use of quites surrounding the wildcard path):
 
 python train.py \
-    --data_fp "./data/larc-split/train/train/train_4*.csv" \
-    --epochs 20 \
+    --data_fp "./data/larc-split/train/train/train_4[1-5].csv" \
+    --epochs 2 \
     --batch_size 512 \
     --batches_to_take 128 \
     --num_train_clients 16 \
@@ -14,6 +14,7 @@ python train.py \
 
 """
 import argparse
+import os
 import six
 import tensorflow as tf
 
@@ -121,6 +122,7 @@ def execute_federated_training(dataset, logdir: str, training_config: TrainingCo
 
 def execute_centralized_training(dataset, logdir: str, training_config: TrainingConfig,
                                  model_config: ModelConfig):
+    """Execute a complete run of centralized training."""
     target_feature = DEFAULT_LARC_TARGET_COLNAME
     centralized_dataset = dataset.create_tf_dataset(training_config)
     feature_layer = dataset.make_feature_layer()
@@ -154,9 +156,12 @@ def main(data_fp: str, logdir: str, training_config: TrainingConfig,
     dataset = LarcDataset()
     dataset.read_data(data_fp)
     if train_federated:
+        federated_logdir = os.path.join(logdir, "federated")
         execute_federated_training(dataset, logdir, training_config, model_config)
     if train_centralized:
-        execute_centralized_training(dataset, logdir, training_config, model_config)
+        centralized_logdir = os.path.join(logdir, "centralized")
+        execute_centralized_training(dataset, centralized_logdir, training_config,
+                                     model_config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes data-joining issues which occurred (silently) due to improper indexing and joining of different dataframes; these have been resolved and also made explicit (if they do occur) through use of inner rather than left joins.

Additionally, this PR explicitly conducts the sharding of training data into multiple smaller CSV files (100 by default).